### PR TITLE
Safely handle missing GameManager instance

### DIFF
--- a/First Game/Assets/Scripts/PlayerHealth.cs
+++ b/First Game/Assets/Scripts/PlayerHealth.cs
@@ -22,16 +22,26 @@ public class PlayerHealth : MonoBehaviour
 
     private void OnEnable()
     {
-        GameManager.Instance.OnGameStart += Init;
-        GameManager.Instance.OnGameRestart += Init;
-        
-        Debug.Log("GameManager is: " + GameManager.Instance.enabled);
+        if (GameManager.Instance != null)
+        {
+            GameManager.Instance.OnGameStart += Init;
+            GameManager.Instance.OnGameRestart += Init;
+
+            Debug.Log("GameManager is: " + GameManager.Instance.enabled);
+        }
+        else
+        {
+            Debug.LogWarning("PlayerHealth enabled before GameManager was initialized.");
+        }
     }
 
     private void OnDisable()
     {
-        GameManager.Instance.OnGameStart -= Init;
-        GameManager.Instance.OnGameRestart -= Init;
+        if (GameManager.Instance != null)
+        {
+            GameManager.Instance.OnGameStart -= Init;
+            GameManager.Instance.OnGameRestart -= Init;
+        }
     }
 
     public void TakeDamage(int damage)

--- a/First Game/Assets/Scripts/PlayerMovement.cs
+++ b/First Game/Assets/Scripts/PlayerMovement.cs
@@ -22,14 +22,24 @@ public class PlayerMovement : MonoBehaviour
 
     private void OnEnable()
     {
-        GameManager.Instance.OnGameStart += Init;
-        GameManager.Instance.OnGameRestart += Init;
+        if (GameManager.Instance != null)
+        {
+            GameManager.Instance.OnGameStart += Init;
+            GameManager.Instance.OnGameRestart += Init;
+        }
+        else
+        {
+            Debug.LogWarning("PlayerMovement enabled before GameManager was initialized.");
+        }
     }
 
     private void OnDisable()
     {
-        GameManager.Instance.OnGameStart -= Init;
-        GameManager.Instance.OnGameRestart -= Init;
+        if (GameManager.Instance != null)
+        {
+            GameManager.Instance.OnGameStart -= Init;
+            GameManager.Instance.OnGameRestart -= Init;
+        }
     }
 
     private void Start()

--- a/First Game/Assets/Scripts/ScoreManager.cs
+++ b/First Game/Assets/Scripts/ScoreManager.cs
@@ -9,19 +9,32 @@ public class ScoreManager : MonoBehaviour
     [SerializeField] private int score;
     [SerializeField] private TMP_Text scoreText;
 
-    private void OnEnable()
+    private void Awake()
     {
         if (Instance == null) Instance = this;
         else Destroy(gameObject);
+    }
 
-        GameManager.Instance.OnGameStart += Init;
-        GameManager.Instance.OnGameRestart += Init;
+    private void Start()
+    {
+        if (GameManager.Instance != null)
+        {
+            GameManager.Instance.OnGameStart += Init;
+            GameManager.Instance.OnGameRestart += Init;
+        }
+        else
+        {
+            Debug.LogWarning("GameManager instance not found when ScoreManager started.");
+        }
     }
 
     private void OnDisable()
     {
-        GameManager.Instance.OnGameStart -= Init;
-        GameManager.Instance.OnGameRestart -= Init;
+        if (GameManager.Instance != null)
+        {
+            GameManager.Instance.OnGameStart -= Init;
+            GameManager.Instance.OnGameRestart -= Init;
+        }
     }
 
     private void Init()

--- a/First Game/Assets/Scripts/Spawner.cs
+++ b/First Game/Assets/Scripts/Spawner.cs
@@ -157,16 +157,26 @@ public class Spawner : MonoBehaviour
 
     private void Awake()
     {
-        GameManager.Instance.OnGameStart += Init;
-        GameManager.Instance.OnGameRestart += Init;
-        GameManager.Instance.OnGameOver += StopSpawning;
+        if (GameManager.Instance != null)
+        {
+            GameManager.Instance.OnGameStart += Init;
+            GameManager.Instance.OnGameRestart += Init;
+            GameManager.Instance.OnGameOver += StopSpawning;
+        }
+        else
+        {
+            Debug.LogWarning("Spawner awakened before GameManager was initialized.");
+        }
     }
 
     private void OnDisable()
     {
-        GameManager.Instance.OnGameStart -= Init;
-        GameManager.Instance.OnGameRestart -= Init;
-        GameManager.Instance.OnGameOver -= StopSpawning;
+        if (GameManager.Instance != null)
+        {
+            GameManager.Instance.OnGameStart -= Init;
+            GameManager.Instance.OnGameRestart -= Init;
+            GameManager.Instance.OnGameOver -= StopSpawning;
+        }
     }
 
     private void Init()

--- a/First Game/Assets/Scripts/SpawnerMovement.cs
+++ b/First Game/Assets/Scripts/SpawnerMovement.cs
@@ -18,14 +18,24 @@ public class SpawnerMovement : MonoBehaviour
 
     private void OnEnable()
     {
-        GameManager.Instance.OnGameStart += Init;
-        GameManager.Instance.OnGameRestart += Init;
+        if (GameManager.Instance != null)
+        {
+            GameManager.Instance.OnGameStart += Init;
+            GameManager.Instance.OnGameRestart += Init;
+        }
+        else
+        {
+            Debug.LogWarning("SpawnerMovement enabled before GameManager was initialized.");
+        }
     }
 
     private void OnDisable()
     {
-        GameManager.Instance.OnGameStart -= Init;
-        GameManager.Instance.OnGameRestart -= Init;
+        if (GameManager.Instance != null)
+        {
+            GameManager.Instance.OnGameStart -= Init;
+            GameManager.Instance.OnGameRestart -= Init;
+        }
     }
     /*private void Start()
     {


### PR DESCRIPTION
## Summary
- prevent null reference by waiting for GameManager before registering score manager events
- guard PlayerHealth, PlayerMovement, Spawner, and SpawnerMovement event hookups

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895ccd7e394832b859a62d9e1587e11